### PR TITLE
Fix navbar position in chatrooms

### DIFF
--- a/app/views/chatrooms/show.html.erb
+++ b/app/views/chatrooms/show.html.erb
@@ -1,7 +1,4 @@
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-
-<div class="chat-container mt-5">
+<div class="chat-container">
 <%= link_to chatrooms_path, class: "back-button" do %>
   <i class="fas fa-chevron-left"></i>
 <% end %>


### PR DESCRIPTION
J'ai supprimé les imports en doublon sur la page qui causaient ce bug (navbar en haut sur mobile).